### PR TITLE
refactor: replace manual YAML parser with serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,8 @@ dependencies = [
  "mime_guess",
  "prometheus",
  "serde",
+ "serde_yaml",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "tower",
@@ -661,6 +663,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -947,6 +962,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ axum = "0.6"
 hyper = "0.14"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
-# serde_yaml = "0.9"  # unused: manual YAML parsing
+serde_yaml = "0.9"
 # tower-http = { version = "0.3", features = ["fs"] }  # unused: manual fs handler
 mime_guess = "2.0"
 arc-swap = "1.6"
@@ -18,3 +18,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "json", "env-filter"] }
 # thiserror = "1.0"  # unused: generic Box<Error>
 toml = "0.7"
+thiserror = "1.0"

--- a/links.yaml
+++ b/links.yaml
@@ -1,3 +1,4 @@
- # links.yaml - mapping of short codes to full URLs
- foo: https://example.com | optional comments per line, space-pipe-space as delimiter
- bar: https://example.com
+# links.yaml - mapping of short codes to full URLs
+foo: https://example.com # Comments are now standard YAML comments
+bar: https://example.org
+test: https://test.example.com

--- a/scripts/convert_links_format.sh
+++ b/scripts/convert_links_format.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Script to convert links.yaml from old format (pipe-delimited comments) to new format (YAML comments)
+# (C) Copyright 2025, Joseph R. Jones - https://jrj.org - Licensed under MIT License
+
+set -euo pipefail
+
+INPUT_FILE="${1:-links.yaml}"
+OUTPUT_FILE="${2:-links.yaml.new}"
+
+if [ ! -f "$INPUT_FILE" ]; then
+    echo "Error: Input file $INPUT_FILE does not exist."
+    echo "Usage: $0 [input_file] [output_file]"
+    exit 1
+fi
+
+# Create a backup of the original file
+cp "$INPUT_FILE" "$INPUT_FILE.bak"
+echo "Created backup at $INPUT_FILE.bak"
+
+# Make sure the output file is empty/new
+> "$OUTPUT_FILE"
+
+# Process the file line by line
+while IFS= read -r line || [ -n "$line" ]; do  # The [ -n "$line" ] handles the last line if it doesn't end with a newline
+    # Skip empty lines or already converted comments
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        echo "$line" >> "$OUTPUT_FILE"
+        continue
+    fi
+    
+    # Handle lines with pipe-delimited comments
+    if [[ "$line" == *" | "* ]]; then
+        # Split line at " | " and convert to YAML comment format
+        key_value="${line%% | *}"
+        comment="${line#* | }"
+        echo "$key_value # $comment" >> "$OUTPUT_FILE"
+    else
+        # No comment delimiter, pass through as is
+        echo "$line" >> "$OUTPUT_FILE"
+    fi
+done < "$INPUT_FILE"
+
+echo "Conversion complete. New file created at $OUTPUT_FILE"
+echo "To replace the original file, run: mv $OUTPUT_FILE $INPUT_FILE"

--- a/scripts/export_yourls.sh
+++ b/scripts/export_yourls.sh
@@ -16,10 +16,11 @@ else
         echo "Error: mysql client not found. Install mysql-client or set YOURLS_DOCKER_CONTAINER." >&2
         exit 1
     fi
-    DB_CMD=(mysql --protocol=TCP -h "$YOURLS_DB_HOST" -P "$YOURLS_DB_PORT" -u "$YOURLS_DB_USER" -p"$YOURLS_DB_PASS")
+    DB_CMD=(mysql --protocol=TCP -h "$YOURLS_DB_HOST" -P "${YOURLS_DB_PORT:-3306}" -u "$YOURLS_DB_USER" -p"$YOURLS_DB_PASS")
 fi
 
 # Export YOURLS mappings to a YAML file suitable for Redirective
+# Uses the new YAML comment format (standard # comments) instead of the legacy pipe-delimited format
 #
 # Environment variables required:
 #   YOURLS_DB_HOST   - MySQL host for YOURLS database
@@ -38,9 +39,9 @@ fi
 "${DB_CMD[@]}" "$YOURLS_DB_NAME" -Nse \
     "SELECT keyword, url, IFNULL(title, '') FROM yourls_url ORDER BY keyword;" |
 while IFS=$'\t' read -r key url title; do
-    # Output as YAML mapping, append title as comment if present
+    # Output as YAML mapping, append title as standard YAML comment if present
     if [[ -n "$title" ]]; then
-        echo "${key}: ${url} | ${title}"
+        echo "${key}: ${url} # ${title}"
     else
         echo "${key}: ${url}"
     fi

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,19 +6,47 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 
+/// Links YAML structure with support for comments.
+#[derive(Deserialize, Debug)]
+#[serde(transparent)]
+pub struct Links {
+    /// Mapping of codes to target URLs.
+    pub links: HashMap<String, String>,
+}
+
 /// Service configuration parameters.
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
 pub struct ServiceConfig {
     /// The address (host:port) to bind the HTTP server to.
+    #[serde(default = "default_address")]
     pub address: String,
     /// (Deprecated) Reload interval no longer used; webhook triggers reload.
     // pub reload_interval_secs: u64,
     /// HTTP path for the reload webhook endpoint.
+    #[serde(default = "default_webhook_path")]
     pub webhook_path: String,
     /// Max reload webhook requests per minute per IP.
+    #[serde(default = "default_rate_limit_minute")]
     pub rate_limit_per_minute: u32,
     /// Max reload webhook requests per day per IP.
+    #[serde(default = "default_rate_limit_day")]
     pub rate_limit_per_day: u32,
+}
+
+fn default_address() -> String {
+    "0.0.0.0:8080".to_string()
+}
+
+fn default_webhook_path() -> String {
+    "/git-webhook".to_string()
+}
+
+fn default_rate_limit_minute() -> u32 {
+    1
+}
+
+fn default_rate_limit_day() -> u32 {
+    100
 }
 
 /// Overall application configuration.
@@ -29,60 +57,47 @@ pub struct Config {
     pub service: ServiceConfig,
 }
 
+#[derive(Deserialize)]
+struct RawWebhookConfig {
+    path: Option<String>,
+    rate_limit_per_minute: Option<u32>,
+    rate_limit_per_day: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct RawServiceConfig {
+    address: Option<String>,
+    webhook: Option<RawWebhookConfig>,
+}
+
 impl Config {
     /// Load configuration from `links.yaml` and optional service settings.
     pub fn load(links_path: &str) -> Result<Self, Error> {
         // Read links file and parse mappings
         let content = fs::read_to_string(links_path)?;
-        let mut links = HashMap::new();
-        for (idx, line) in content.lines().enumerate() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
+        
+        // Parse YAML using serde_yaml
+        let links_data: Links = serde_yaml::from_str(&content)
+            .map_err(|e| Error::Config(format!("Failed to parse YAML: {}", e)))?;
+            
+        let links = links_data.links;
+        
+        // Validate URLs are not empty
+        for (key, url) in &links {
+            if url.trim().is_empty() {
+                return Err(Error::Config(format!("Empty URL for key '{}'", key)));
             }
-            // Expect format: key: value [| comment]
-            let parts: Vec<&str> = line.splitn(2, ':').collect();
-            if parts.len() != 2 {
-                return Err(format!("Invalid line in links.yaml at {}: {}", idx + 1, line).into());
-            }
-            let key = parts[0].trim().to_string();
-            let rest = parts[1].trim();
-            // Strip inline comments after '|'
-            // Take part before inline comment and trim
-            let mut url = rest.split('|').next().unwrap().trim().to_string();
-            // Strip surrounding single or double quotes, if present
-            url = url.trim_matches(|c| c == '"' || c == '\'').to_string();
-            if url.is_empty() {
-                return Err(format!(
-                    "Empty URL for key '{}' in links.yaml at line {}",
-                    key,
-                    idx + 1
-                )
-                .into());
-            }
-            links.insert(key, url);
         }
 
-        // Read service settings from redirective.toml, if available
-        #[derive(Deserialize)]
-        struct RawWebhookConfig {
-            path: Option<String>,
-            rate_limit_per_minute: Option<u32>,
-            rate_limit_per_day: Option<u32>,
-        }
-
-        #[derive(Deserialize)]
-        struct RawServiceConfig {
-            address: Option<String>,
-            webhook: Option<RawWebhookConfig>,
-        }
         // Default settings
         let mut service = ServiceConfig {
-            address: "0.0.0.0:8080".to_string(),
-            webhook_path: "/git-webhook".to_string(),
-            rate_limit_per_minute: 1,
-            rate_limit_per_day: 100,
+            address: default_address(),
+            webhook_path: default_webhook_path(),
+            rate_limit_per_minute: default_rate_limit_minute(),
+            rate_limit_per_day: default_rate_limit_day(),
         };
+        
+        // Read service settings from redirective.toml, if available
         if let Ok(toml_str) = fs::read_to_string("redirective.toml") {
             let raw: RawServiceConfig = toml::from_str(&toml_str)?;
             if let Some(addr) = raw.address {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,43 @@
 // (C) Copyright 2025, Joseph R. Jones - https://jrj.org - Licensed under MIT License
 //! errors module: central error type for redirective service.
 
-/// A generic error type for the application.
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
+use thiserror::Error;
+use std::net::AddrParseError;
+use hyper::Error as HyperError;
+
+/// Typed errors for the application
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    
+    #[error("YAML parsing error: {0}")]
+    YamlParse(#[from] serde_yaml::Error),
+    
+    #[error("TOML parsing error: {0}")]
+    TomlParse(#[from] toml::de::Error),
+    
+    #[error("Address parsing error: {0}")]
+    AddrParse(#[from] AddrParseError),
+    
+    #[error("HTTP server error: {0}")]
+    Http(#[from] HyperError),
+    
+    #[error("Config error: {0}")]
+    Config(String),
+    
+    #[error("Other error: {0}")]
+    Other(String),
+}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Error::Other(s)
+    }
+}
+
+impl From<&str> for Error {
+    fn from(s: &str) -> Self {
+        Error::Other(s.to_string())
+    }
+}


### PR DESCRIPTION
- Replace hand-rolled YAML parser with serde_yaml for links.yaml
- Update links format to use standard YAML comments (# instead of | for comments)
- Create Links struct that derives Deserialize for YAML parsing
- Implement thiserror for typed error handling
- Create conversion script to update existing links.yaml files
- Fix DB_PORT parameter usage in YOURLS export script
- Update YOURLS export to use new comment format

🤖 Generated with [Claude Code](https://claude.ai/code)

Edited to add: resolves issue #7 