### PR TITLE
Add webhook peer relay for multi-node hot-reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bytes"
@@ -132,10 +132,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "equivalent"
@@ -144,10 +170,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -189,6 +252,18 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -261,6 +336,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +375,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -358,7 +452,24 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -385,6 +496,49 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -454,6 +608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,12 +667,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redirective"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axum",
  "hyper",
+ "hyper-tls",
  "mime_guess",
  "prometheus",
  "serde",
@@ -531,7 +698,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -585,6 +752,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,10 +777,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -688,6 +900,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,7 +927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -728,6 +946,19 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "thiserror"
@@ -794,7 +1025,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -806,6 +1037,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -976,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,6 +1236,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1013,12 +1269,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1093,3 +1364,9 @@ checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2024"
 [dependencies]
 tower = "0.4"
 axum = "0.6"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["client", "http1"] }
+hyper-tls = "0.5" # TLS for webhook peer-relay client (platform TLS via native-tls)
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,37 @@ This project was done in part because I was using [Yourls](https://github.com/YO
 ## Features:
  - Thread-safe, lock-free reads with `ArcSwap`.
  - Hot-reload of mappings on demand via an HTTP webhook (`POST /git-webhook` by default) that pulls the latest `links.yaml` from Git and reloads.
+ - Optional webhook peer relay for multi-node deployments (see below).
  - Prometheus metrics and structured JSON logging.
- 
+
+### Hot-reload peer relay
+
+In an active/standby deployment (e.g. two nodes behind DNS failover), GitHub delivers a single push webhook, which only reaches the active node — the standby's link table would go stale. Setting `peer_url` in the `[webhook]` section makes a node relay the webhook to its peer **after a successful reload**:
+
+ - The relayed request is a `POST` to `peer_url` carrying the header `X-Redirective-Relay: 1`, sent fire-and-forget with a 5-second timeout. Relay failures are logged and counted (`relay_success` / `relay_fail` metrics) but never affect the webhook response or the local reload.
+ - A request that arrives **with** `X-Redirective-Relay` is never relayed again. This makes the config loop-free even when both nodes point at each other: node A relays to node B, node B reloads and stops.
+ - Failed reloads are not relayed.
+ - `peer_url` absent (the default) disables the feature entirely.
+
+Symmetric two-node example — on `corellia`:
+
+```toml
+[webhook]
+peer_url = "https://tatooine.rimrock.systems/git-webhook"
+```
+
+and on `tatooine`:
+
+```toml
+[webhook]
+peer_url = "https://corellia.rimrock.systems/git-webhook"
+```
+
+The URL must be reachable node-to-node (if public hostnames only resolve through a proxy/CDN, use a direct or private address instead). Relayed requests pass through the normal webhook rate limiter on the receiving node.
+
 ## Configuration
  - `links.yaml`: contains mappings from codes to URLs. Example provided.
- - `redirective.toml`: service settings (bind address, webhook path, rate limits).
+ - `redirective.toml`: service settings (bind address, webhook path, rate limits, optional `peer_url` for the webhook peer relay).
  
 ## Development
 ## Utilities

--- a/redirective.toml
+++ b/redirective.toml
@@ -4,3 +4,7 @@ address = "0.0.0.0:8080"
 path = "/git-webhook"
 rate_limit_per_minute = 1
 rate_limit_per_day = 100
+# Optional: relay reload webhooks to a peer node after a successful reload.
+# The relayed request carries the X-Redirective-Relay header, which prevents
+# relay loops (a relayed request is never relayed again). Absent = disabled.
+# peer_url = "https://tatooine.rimrock.systems/git-webhook"

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,10 @@ pub struct ServiceConfig {
     /// Max reload webhook requests per day per IP.
     #[serde(default = "default_rate_limit_day")]
     pub rate_limit_per_day: u32,
+    /// Optional peer webhook URL to relay reload webhooks to (e.g. the
+    /// standby node's `/git-webhook` endpoint). Absent = relay disabled.
+    #[serde(default)]
+    pub peer_url: Option<String>,
 }
 
 fn default_address() -> String {
@@ -62,6 +66,7 @@ struct RawWebhookConfig {
     path: Option<String>,
     rate_limit_per_minute: Option<u32>,
     rate_limit_per_day: Option<u32>,
+    peer_url: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -95,6 +100,7 @@ impl Config {
             webhook_path: default_webhook_path(),
             rate_limit_per_minute: default_rate_limit_minute(),
             rate_limit_per_day: default_rate_limit_day(),
+            peer_url: None,
         };
 
         // Read service settings from redirective.toml, if available
@@ -112,6 +118,9 @@ impl Config {
                 }
                 if let Some(day) = webhook_raw.rate_limit_per_day {
                     service.rate_limit_per_day = day;
+                }
+                if let Some(peer) = webhook_raw.peer_url {
+                    service.peer_url = Some(peer);
                 }
             }
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -12,7 +12,7 @@ use crate::metrics::Metrics;
 use axum::{
     Router,
     extract::{ConnectInfo, Extension, Query},
-    http::{StatusCode, Uri, header},
+    http::{HeaderMap, StatusCode, Uri, header},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
@@ -20,10 +20,22 @@ use mime_guess::from_path;
 use prometheus::{Encoder, TextEncoder};
 use serde::Deserialize;
 use std::path::Path as FsPath;
+
+/// Header marking a webhook request as relayed from a peer node.
+/// Requests carrying this header are never relayed again (loop prevention).
+const RELAY_HEADER: &str = "x-redirective-relay";
+
+/// Path to the git binary used for reload pulls.
+const GIT_BINARY: &str = "/usr/bin/git";
+
+/// Timeout for relaying the webhook to the peer node.
+const RELAY_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Configuration for the reload webhook.
 #[derive(Clone)]
 struct WebhookConfig {
     path: String,
+    peer_url: Option<String>,
 }
 
 /// Rate limit information per client IP.
@@ -120,6 +132,7 @@ fn create_app(
         )),
         webhook_config: WebhookConfig {
             path: service.webhook_path.clone(),
+            peer_url: service.peer_url.clone(),
         },
     };
     let mut router = Router::new()
@@ -240,39 +253,88 @@ async fn spa_handler(Extension(state): Extension<AppState>, uri: Uri) -> Respons
         .into_response()
 }
 
-/// Webhook endpoint to trigger a git pull and reload.
-async fn webhook_handler(
-    ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    Extension(state): Extension<AppState>,
-) -> impl IntoResponse {
-    let ip = addr.ip();
-    if !state.rate_limiter.allow(ip).await {
-        return StatusCode::TOO_MANY_REQUESTS.into_response();
+/// Decide whether this webhook should be relayed to a peer.
+///
+/// Returns the peer URL to relay to when `peer_url` is configured and the
+/// incoming request did not itself arrive via relay (no `X-Redirective-Relay`
+/// header). A relayed request is never relayed again, so two nodes pointing
+/// at each other cannot loop.
+fn relay_target(peer_url: Option<&str>, headers: &HeaderMap) -> Option<String> {
+    match peer_url {
+        Some(url) if !headers.contains_key(RELAY_HEADER) => Some(url.to_string()),
+        _ => None,
     }
-    let reload_mutex = state.reload_mutex.clone();
-    let cache = state.cache.clone();
-    let metrics = state.metrics.clone();
-    task::spawn(async move {
-        let _guard = reload_mutex.lock().await;
-        let repo_dir = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        let git_binary = "/usr/bin/git";
-        if let Ok(status) = Command::new(git_binary)
-            .current_dir(&repo_dir)
-            .args(["pull", "--ff-only"])
-            .status()
-        {
-            if status.success() {
-                if let Ok(cfg) = Config::load("links.yaml") {
-                    if env::current_dir().is_ok() {
-                        let mut codes: Vec<String> = cfg.links.keys().cloned().collect();
-                        codes.sort();
-                        let content = codes.join("\n");
-                        let _ = std::fs::write("static_html/shortcodes.txt", &content);
-                    }
-                    cache.swap(cfg.links);
-                    metrics.reload_success.inc();
-                } else {
-                    metrics.reload_fail.inc();
+}
+
+/// Fire a relay POST to the peer's webhook endpoint, marking it with the
+/// relay-guard header. Failures are logged and counted but never propagate.
+async fn relay_to_peer(peer_url: &str, metrics: &Metrics) {
+    let request = hyper::Request::builder()
+        .method(hyper::Method::POST)
+        .uri(peer_url)
+        .header(RELAY_HEADER, "1")
+        .body(hyper::Body::empty());
+    let request = match request {
+        Ok(req) => req,
+        Err(e) => {
+            tracing::error!(peer = peer_url, error = %e, "invalid peer_url; relay skipped");
+            metrics.relay_fail.inc();
+            return;
+        }
+    };
+    let client = hyper::Client::builder().build(hyper_tls::HttpsConnector::new());
+    match tokio::time::timeout(RELAY_TIMEOUT, client.request(request)).await {
+        Ok(Ok(resp)) if resp.status().is_success() => {
+            tracing::info!(peer = peer_url, status = %resp.status(), "relayed webhook to peer");
+            metrics.relay_success.inc();
+        }
+        Ok(Ok(resp)) => {
+            tracing::warn!(peer = peer_url, status = %resp.status(), "peer relay rejected");
+            metrics.relay_fail.inc();
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(peer = peer_url, error = %e, "peer relay failed");
+            metrics.relay_fail.inc();
+        }
+        Err(_) => {
+            tracing::warn!(
+                peer = peer_url,
+                timeout_secs = RELAY_TIMEOUT.as_secs(),
+                "peer relay timed out"
+            );
+            metrics.relay_fail.inc();
+        }
+    }
+}
+
+/// Run a git pull and reload the link table, then (only on a successful
+/// reload) relay the webhook to `relay_target`, if any. Relay failures do
+/// not affect the reload outcome.
+async fn reload_and_relay(
+    cache: RouterCache,
+    metrics: Metrics,
+    relay_target: Option<String>,
+    git_binary: &str,
+) {
+    let repo_dir = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    if let Ok(status) = Command::new(git_binary)
+        .current_dir(&repo_dir)
+        .args(["pull", "--ff-only"])
+        .status()
+    {
+        if status.success() {
+            if let Ok(cfg) = Config::load("links.yaml") {
+                if env::current_dir().is_ok() {
+                    let mut codes: Vec<String> = cfg.links.keys().cloned().collect();
+                    codes.sort();
+                    let content = codes.join("\n");
+                    let _ = std::fs::write("static_html/shortcodes.txt", &content);
+                }
+                cache.swap(cfg.links);
+                metrics.reload_success.inc();
+                // Only a successful reload propagates to the peer.
+                if let Some(peer_url) = relay_target {
+                    relay_to_peer(&peer_url, &metrics).await;
                 }
             } else {
                 metrics.reload_fail.inc();
@@ -280,6 +342,28 @@ async fn webhook_handler(
         } else {
             metrics.reload_fail.inc();
         }
+    } else {
+        metrics.reload_fail.inc();
+    }
+}
+
+/// Webhook endpoint to trigger a git pull and reload.
+async fn webhook_handler(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Extension(state): Extension<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let ip = addr.ip();
+    if !state.rate_limiter.allow(ip).await {
+        return StatusCode::TOO_MANY_REQUESTS.into_response();
+    }
+    let relay_target = relay_target(state.webhook_config.peer_url.as_deref(), &headers);
+    let reload_mutex = state.reload_mutex.clone();
+    let cache = state.cache.clone();
+    let metrics = state.metrics.clone();
+    task::spawn(async move {
+        let _guard = reload_mutex.lock().await;
+        reload_and_relay(cache, metrics, relay_target, GIT_BINARY).await;
     });
     StatusCode::ACCEPTED.into_response()
 }
@@ -317,6 +401,7 @@ mod tests {
             webhook_path: "/git-webhook".to_string(),
             rate_limit_per_minute: 1,
             rate_limit_per_day: 100,
+            peer_url: None,
         }
     }
 
@@ -402,5 +487,111 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body()).await.unwrap();
         assert_eq!(&body[..], b"false");
+    }
+
+    /// Spawn a mock peer webhook server on an ephemeral port. Returns its
+    /// webhook URL and a log of the headers of every request it receives.
+    async fn spawn_mock_peer() -> (String, Arc<TokioMutex<Vec<HeaderMap>>>) {
+        let received: Arc<TokioMutex<Vec<HeaderMap>>> = Arc::new(TokioMutex::new(Vec::new()));
+        let log = received.clone();
+        let app = Router::new().route(
+            "/git-webhook",
+            post(move |headers: HeaderMap| {
+                let log = log.clone();
+                async move {
+                    log.lock().await.push(headers);
+                    StatusCode::ACCEPTED
+                }
+            }),
+        );
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(app.into_make_service()),
+        );
+        (format!("http://{}/git-webhook", addr), received)
+    }
+
+    #[test]
+    fn test_relay_target_set_when_peer_configured_and_no_guard() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            relay_target(Some("http://peer/git-webhook"), &headers),
+            Some("http://peer/git-webhook".to_string())
+        );
+    }
+
+    #[test]
+    fn test_relay_target_none_when_guard_header_present() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RELAY_HEADER, "1".parse().unwrap());
+        assert_eq!(
+            relay_target(Some("http://peer/git-webhook"), &headers),
+            None
+        );
+    }
+
+    #[test]
+    fn test_relay_target_none_when_peer_absent() {
+        let headers = HeaderMap::new();
+        assert_eq!(relay_target(None, &headers), None);
+    }
+
+    #[tokio::test]
+    async fn test_relay_fires_after_successful_reload() {
+        let (peer_url, received) = spawn_mock_peer().await;
+        let cache = RouterCache::new(HashMap::new());
+        let metrics = init_metrics();
+        // /usr/bin/true stands in for a git pull that succeeds.
+        reload_and_relay(cache, metrics.clone(), Some(peer_url), "/usr/bin/true").await;
+        assert_eq!(metrics.reload_success.get(), 1);
+        assert_eq!(metrics.relay_success.get(), 1);
+        assert_eq!(metrics.relay_fail.get(), 0);
+        let requests = received.lock().await;
+        assert_eq!(requests.len(), 1);
+        // The relayed request must carry the guard header so the peer
+        // does not relay it back (loop prevention).
+        assert_eq!(requests[0].get(RELAY_HEADER).unwrap(), "1");
+    }
+
+    #[tokio::test]
+    async fn test_no_relay_when_target_none() {
+        let cache = RouterCache::new(HashMap::new());
+        let metrics = init_metrics();
+        reload_and_relay(cache, metrics.clone(), None, "/usr/bin/true").await;
+        assert_eq!(metrics.reload_success.get(), 1);
+        assert_eq!(metrics.relay_success.get(), 0);
+        assert_eq!(metrics.relay_fail.get(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_no_relay_on_failed_reload() {
+        let (peer_url, received) = spawn_mock_peer().await;
+        let cache = RouterCache::new(HashMap::new());
+        let metrics = init_metrics();
+        // /usr/bin/false stands in for a git pull that fails.
+        reload_and_relay(cache, metrics.clone(), Some(peer_url), "/usr/bin/false").await;
+        assert_eq!(metrics.reload_fail.get(), 1);
+        assert_eq!(metrics.relay_success.get(), 0);
+        assert_eq!(metrics.relay_fail.get(), 0);
+        assert!(received.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_relay_failure_counted_but_reload_still_succeeds() {
+        // Bind then drop a listener to get a port with nothing listening.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let cache = RouterCache::new(HashMap::new());
+        let metrics = init_metrics();
+        let peer_url = format!("http://{}/git-webhook", addr);
+        reload_and_relay(cache, metrics.clone(), Some(peer_url), "/usr/bin/true").await;
+        assert_eq!(metrics.reload_success.get(), 1);
+        assert_eq!(metrics.relay_success.get(), 0);
+        assert_eq!(metrics.relay_fail.get(), 1);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,6 +15,10 @@ pub struct Metrics {
     pub reload_success: IntCounter,
     /// Counter of failed config reloads.
     pub reload_fail: IntCounter,
+    /// Counter of successful webhook relays to the peer node.
+    pub relay_success: IntCounter,
+    /// Counter of failed webhook relays to the peer node.
+    pub relay_fail: IntCounter,
     /// The registry holding all metrics.
     pub registry: Arc<Registry>,
 }
@@ -56,11 +60,28 @@ pub fn init_metrics() -> Metrics {
     registry
         .register(Box::new(reload_fail.clone()))
         .expect("failed to register reload_fail");
+    // Counter of successful peer relays
+    let relay_success = IntCounter::new(
+        "relay_success",
+        "Counter of successful webhook relays to peer",
+    )
+    .expect("failed to create relay_success metric");
+    registry
+        .register(Box::new(relay_success.clone()))
+        .expect("failed to register relay_success");
+    // Counter of failed peer relays
+    let relay_fail = IntCounter::new("relay_fail", "Counter of failed webhook relays to peer")
+        .expect("failed to create relay_fail metric");
+    registry
+        .register(Box::new(relay_fail.clone()))
+        .expect("failed to register relay_fail");
     Metrics {
         redirect_total,
         redirect_latency,
         reload_success,
         reload_fail,
+        relay_success,
+        relay_fail,
         registry: Arc::new(registry),
     }
 }
@@ -80,12 +101,16 @@ mod tests {
             .observe(0.0);
         metrics.reload_success.inc();
         metrics.reload_fail.inc();
+        metrics.relay_success.inc();
+        metrics.relay_fail.inc();
         let families = metrics.registry.gather();
         let names: Vec<_> = families.iter().map(|f| f.name()).collect();
         // Ensure counters are registered
         assert!(names.contains(&"redirect_total"));
         assert!(names.contains(&"reload_success"));
         assert!(names.contains(&"reload_fail"));
+        assert!(names.contains(&"relay_success"));
+        assert!(names.contains(&"relay_fail"));
         // Histogram produces bucket, sum, and count families
         assert!(
             names


### PR DESCRIPTION
# Webhook peer relay for multi-node hot-reload

## Design summary

Redirective runs on two cluster nodes (corellia = active, tatooine = standby) behind Cloudflare DNS failover. GitHub delivers one push webhook per push, which only reaches the active node — the standby's link table goes stale until failover plus a fresh push. This PR makes the receiving node propagate the webhook:

- New optional config field `peer_url` in the `[webhook]` section of `redirective.toml` (`RawWebhookConfig` → `ServiceConfig`). Absent = feature off, behavior unchanged.
- `webhook_handler` now extracts request headers. After a reload that **succeeds** (the `cache.swap` path), if `peer_url` is configured and the incoming request did **not** carry the relay-guard header `X-Redirective-Relay`, the node sends a fire-and-forget `POST peer_url` with `X-Redirective-Relay: 1` and a 5-second timeout.
- Failed reloads are never relayed. Relay failures are logged via `tracing` and counted in new Prometheus counters `relay_success` / `relay_fail` (same pattern as `reload_success` / `reload_fail`); they never affect the 202 webhook response or the local reload.
- The relay decision is made *before* the rate-limit-protected background task's work, and relayed requests pass through the receiving node's rate limiter normally — no rate-limiting semantics changed.

## Loop prevention

The guard header makes the symmetric config loop-free: a request that arrives with `X-Redirective-Relay` reloads locally but is never relayed again. GitHub → corellia (no header) → relays to tatooine (header set) → tatooine reloads and stops. Both nodes can point `peer_url` at each other with no relay storms; at most one relay hop per GitHub delivery.

## Dependency choice

- HTTP client is **hyper's own client** (hyper 0.14 is already in-tree via axum; this just enables its `client` + `http1` features). No reqwest.
- `peer_url` may be https, and hyper alone has no TLS connector, so one small dep was added: **hyper-tls 0.5** (platform TLS via native-tls → Security.framework on macOS, OpenSSL on Linux). The Docker runtime image already ships `ca-certificates` and `libssl3` (pulled in by `openssh-client`), so no Dockerfile change was needed. hyper-rustls was the alternative but pulls a much larger tree (ring/rustls/webpki) for the same job.

## Test evidence

Unit tests cover the relay decision (`relay_target`) and the reload→relay flow (`reload_and_relay`, with `/usr/bin/true` / `/usr/bin/false` standing in for the git pull and a real in-process mock peer verifying the guard header):

- relay fires after successful reload when `peer_url` set and no guard header (and the relayed request carries `X-Redirective-Relay: 1`)
- no relay when the guard header is present
- no relay when `peer_url` is absent
- no relay on failed reload
- relay failure increments `relay_fail` but reload still succeeds

```
running 16 tests
test cache::tests::lookup_missing ... ok
test cache::tests::lookup_existing ... ok
test cache::tests::swap_updates ... ok
test http::tests::test_relay_target_none_when_peer_absent ... ok
test http::tests::test_relay_target_set_when_peer_configured_and_no_guard ... ok
test http::tests::test_relay_target_none_when_guard_header_present ... ok
test http::tests::test_available_unused ... ok
test http::tests::test_version ... ok
test http::tests::test_available_used ... ok
test metrics::tests::test_redirect_total_label ... ok
test metrics::tests::test_init_metrics_registration ... ok
test http::tests::test_healthz ... ok
test http::tests::test_no_relay_on_failed_reload ... ok
test http::tests::test_no_relay_when_target_none ... ok
test http::tests::test_relay_failure_counted_but_reload_still_succeeds ... ok
test http::tests::test_relay_fires_after_successful_reload ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`cargo clippy --all-targets -- -D warnings` and `cargo fmt -- --check` are clean.

Also verified end-to-end with the real binary (scratch clone, mock peer on localhost): a plain `POST /git-webhook` produced exactly one relayed request with `relay-header=1` at the peer (`relay_success 1`, `reload_success` incremented); a second POST carrying `X-Redirective-Relay: 1` reloaded but did **not** relay (counters unchanged).

## Deployment note (ops decision required)

To enable, ops must set `peer_url` on **each** node, pointing at the other:

- corellia: `peer_url = "https://tatooine.rimrock.systems/git-webhook"`
- tatooine: `peer_url = "https://corellia.rimrock.systems/git-webhook"`

The address must be reachable **node-to-node**. The public hostnames are Cloudflare-locked from outside, so if node-to-node traffic can't reach them directly, use tailnet or direct/LAN addresses (plain `http://` to a direct address works too) — which address to use is an ops decision to make at rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
