### PR TITLE
Harden entrypoint: fail loud on missing links (LINKS_REQUIRED) — ops#138

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,28 +2,70 @@
 set -eu
 
 LINKS_REPO="git@github.com:jrjones/redirective-links.git"
+DEPLOY_KEY="/run/secrets/links_deploy_key"
 
-# Install deploy key if provided and configure SSH for git
-if [ -f /run/secrets/links_deploy_key ]; then
+# LINKS_REQUIRED gates the fail-loud behavior. Prod MUST set LINKS_REQUIRED=1
+# (see the container-cluster compose): the real links repo must be cloned into
+# /app, and if the deploy key is missing OR the git fetch/checkout fails we
+# exit non-zero and crash-loop instead of silently serving the bundled STUB
+# links.yaml (foo/bar/test). That stub-serving failure took down all ~167 real
+# jrj.io short-links once (ops#138) precisely because it was silent.
+#
+# Dev keeps the friendly default: LINKS_REQUIRED unset/0 + no deploy key =>
+# serve the bundled stub, no network, no crash.
+LINKS_REQUIRED="${LINKS_REQUIRED:-0}"
+
+fail() {
+  echo "FATAL(entrypoint): $1" >&2
+  echo "FATAL(entrypoint): LINKS_REQUIRED=1 — refusing to start on stub links.yaml. Fix the deploy key / links sync and redeploy." >&2
+  exit 1
+}
+
+if [ -f "$DEPLOY_KEY" ]; then
+  # Install deploy key and configure SSH for git
   mkdir -p /root/.ssh
-  cp /run/secrets/links_deploy_key /root/.ssh/id_ed25519
+  cp "$DEPLOY_KEY" /root/.ssh/id_ed25519
   chmod 600 /root/.ssh/id_ed25519
   # Add GitHub to known hosts to avoid interactive prompt
   ssh-keyscan -t ed25519 github.com >> /root/.ssh/known_hosts 2>/dev/null || true
   export GIT_SSH_COMMAND="ssh -i /root/.ssh/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
 
-  # Clone the links repo into /app if not already a git repo
-  # This makes /app the redirective-links repo so git pull works
+  # Clone the links repo into /app if not already a git repo.
+  # This makes /app the redirective-links repo so `git pull` (webhook reload) works.
   if [ ! -d /app/.git ]; then
     echo "Initializing git repo for links..."
     cd /app
-    git init
+    git init -q
     git remote add origin "$LINKS_REPO"
-    git fetch origin main
-    # Remove bundled links.yaml to allow checkout, then checkout main tracking origin
-    rm -f links.yaml
-    git checkout -b main origin/main
-    echo "Links repository initialized."
+    if git fetch origin main; then
+      # The bundled stub links.yaml is untracked and would block the checkout;
+      # stash a copy so we can restore it if checkout unexpectedly fails in dev.
+      cp links.yaml /tmp/links.stub.yaml 2>/dev/null || true
+      rm -f links.yaml
+      if git checkout -b main origin/main; then
+        echo "Links repository initialized from $LINKS_REPO."
+      elif [ "$LINKS_REQUIRED" = "1" ]; then
+        fail "'git checkout origin/main' failed"
+      else
+        echo "WARN: checkout failed; restoring bundled stub links.yaml (LINKS_REQUIRED!=1)." >&2
+        cp /tmp/links.stub.yaml links.yaml 2>/dev/null || true
+      fi
+    elif [ "$LINKS_REQUIRED" = "1" ]; then
+      fail "'git fetch origin main' failed"
+    else
+      echo "WARN: git fetch failed; keeping bundled stub links.yaml (LINKS_REQUIRED!=1)." >&2
+    fi
+  fi
+elif [ "$LINKS_REQUIRED" = "1" ]; then
+  fail "deploy key $DEPLOY_KEY is missing"
+fi
+
+# Belt-and-suspenders: in prod the links repo must actually be present. If we
+# somehow reach here under LINKS_REQUIRED=1 without /app/.git, we would serve
+# the stub — refuse.
+if [ "$LINKS_REQUIRED" = "1" ]; then
+  if [ ! -d /app/.git ]; then
+    fail "/app/.git absent after init — links repo not present, would serve stub"
   fi
 fi
 


### PR DESCRIPTION
**Draft.** Fixes the silent-stub failure mode behind **operations#138**.

## Root cause (confirmed)
`scripts/entrypoint.sh` clones `jrjones/redirective-links` into `/app` **only if `/run/secrets/links_deploy_key` exists**; otherwise it silently keeps the bundled STUB `links.yaml` (`foo`/`bar`/`test`). On the re-provisioned Lightsail nodes the deploy key was never restored, so the clone was skipped and every real jrj.io short-link fell through `spa_handler` to `index.html` (HTTP 200) instead of a 302. No crash, no unhealthy `/healthz`, `reload_success`/`reload_fail` both 0. There is no other links-delivery path — startup loads `links.yaml` from CWD (`Config::load`), and the only refresh is the `/git-webhook` → `git pull` path, which needs the repo already cloned.

## Change
Gate a **fail-loud** mode on a new `LINKS_REQUIRED` env var (prod sets `=1`):

| key present | LINKS_REQUIRED | fetch/checkout | result |
|---|---|---|---|
| no | unset/0 | — | serve stub, start (dev) |
| no | 1 | — | **FATAL, exit 1 (crash-loop)** |
| yes | 1 | ok | clone real links, start |
| yes | 1 | fail | **FATAL, exit 1 (crash-loop)** |
| yes | unset/0 | fail | warn, start on stub (dev) |

Plus a belt-and-suspenders guard: under `LINKS_REQUIRED=1`, refuse to start if `/app/.git` is absent after init. Script is written to be safe under `set -e` (no `[ ] && cmd` shorthands). Verified all six scenarios in a sandbox with mocked git.

## Requires (hand back to infrabot)
1. **ECR rebuild + push**: this changes the baked-in entrypoint, so `redirective:latest` must be rebuilt via `scripts/build-redirective.sh` and pulled by the nodes. **Not doing that here — infrabot owns the gated prod build/deploy.**
2. **Compose env** (operations repo, `container-cluster/docker-compose.yml`, `redirective` service): add `LINKS_REQUIRED=1` so prod actually opts into fail-loud. One-liner under `environment:`:
   ```yaml
       environment:
         - RUST_LOG=info
         - LINKS_REQUIRED=1
   ```
   Without this the new code is inert (defaults to dev-safe). With it, a future missing-key node crash-loops loudly instead of silently serving the stub.

Identified as: ada