### PR TITLE
Poll-based link propagation + real-client-IP rate limiting (ops#164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # Must match Dockerfile's `FROM rust:<ver>-slim` and rust-toolchain.toml — see the
-      # comment in rust-toolchain.toml. `stable` + `override: true` floated CI ahead of
-      # the image (clippy on a newer stable demanded let-chains that the older builder
-      # cannot compile), and a floating channel also lets an unrelated Rust release break
-      # this repo's CI with no change of ours.
+      # comment in rust-toolchain.toml. A floating `stable` also lets an unrelated Rust
+      # release break this repo's CI with no change of ours.
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.86"
+          toolchain: "1.97"
           profile: minimal
           override: true
           components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # Must match Dockerfile's `FROM rust:<ver>-slim` and rust-toolchain.toml — see the
+      # comment in rust-toolchain.toml. `stable` + `override: true` floated CI ahead of
+      # the image (clippy on a newer stable demanded let-chains that the older builder
+      # cannot compile), and a floating channel also lets an unrelated Rust release break
+      # this repo's CI with no change of ours.
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: "1.86"
           profile: minimal
           override: true
+          components: clippy, rustfmt
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: build
-FROM rust:1.86-slim AS builder
+FROM rust:1.97-slim AS builder
 WORKDIR /usr/src/app
 # Install dependencies for building
 RUN apt-get update && apt-get install -y pkg-config libssl-dev git ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # Stage 1: build
-FROM rust:1.97-slim AS builder
+# -slim-bookworm, NOT -slim: the builder's Debian release must match the runtime stage
+# below. Bare `rust:1.97-slim` is trixie (glibc 2.41) and links the binary against
+# GLIBC_2.39+, which bookworm (glibc 2.36) cannot load — the image builds and pushes
+# clean, then the container exits 1 on `version GLIBC_2.39 not found`.
+FROM rust:1.97-slim-bookworm AS builder
 WORKDIR /usr/src/app
 # Install dependencies for building
 RUN apt-get update && apt-get install -y pkg-config libssl-dev git ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/redirective.toml
+++ b/redirective.toml
@@ -1,10 +1,26 @@
  # redirective.toml - service settings
 address = "0.0.0.0:8080"
+
+# Every setting below can also be set via a REDIRECTIVE_* env var, which
+# takes precedence over this file (see src/config.rs). Env vars:
+# REDIRECTIVE_POLL_INTERVAL_SECS, REDIRECTIVE_RATE_LIMIT_PER_MINUTE,
+# REDIRECTIVE_RATE_LIMIT_PER_DAY, REDIRECTIVE_PEER_URL.
+
+[poll]
+# Each node independently `git pull`s and reloads links.yaml on this
+# interval, so both cluster nodes converge without depending on the
+# webhook. 0 (or omitting this section) disables polling.
+interval_secs = 60
+
 [webhook]
 path = "/git-webhook"
-rate_limit_per_minute = 1
+# The webhook is an optional accelerator now that polling exists; its only
+# callers are CI/deploy, so a generous limit costs nothing.
+rate_limit_per_minute = 30
 rate_limit_per_day = 100
 # Optional: relay reload webhooks to a peer node after a successful reload.
 # The relayed request carries the X-Redirective-Relay header, which prevents
 # relay loops (a relayed request is never relayed again). Absent = disabled.
+# Not set in prod: the fleet is off-tailnet and nginx 444s direct-IP hits,
+# so a reachable peer path needs new nginx/firewall work polling avoids.
 # peer_url = "https://tatooine.rimrock.systems/git-webhook"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+# Match Dockerfile's `FROM rust:1.86-slim`. A newer local toolchain silently accepts
+# language features (let-chains, stabilized in 1.88) that the release build rejects,
+# so `cargo test` passes on a laptop while `cargo build --release` fails in CI.
+channel = "1.86"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,10 @@
 [toolchain]
-# Match Dockerfile's `FROM rust:1.86-slim`. A newer local toolchain silently accepts
-# language features (let-chains, stabilized in 1.88) that the release build rejects,
-# so `cargo test` passes on a laptop while `cargo build --release` fails in CI.
+# THREE places pin the toolchain and they must move together: this file, Dockerfile's
+# `FROM rust:1.86-slim`, and .github/workflows/ci.yml.
+#
+# They used to disagree. CI floated on `stable` while the image built on 1.86, so a
+# laptop and CI would accept language features (let-chains, stabilized in 1.88) that the
+# release build rejects — and clippy on a newer stable actively DEMANDS them
+# (collapsible_if), which the image then cannot compile. Satisfying one broke the other.
 channel = "1.86"
 components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,11 @@
 [toolchain]
 # THREE places pin the toolchain and they must move together: this file, Dockerfile's
-# `FROM rust:1.86-slim`, and .github/workflows/ci.yml.
+# `FROM rust:1.97-slim`, and .github/workflows/ci.yml.
 #
-# They used to disagree. CI floated on `stable` while the image built on 1.86, so a
-# laptop and CI would accept language features (let-chains, stabilized in 1.88) that the
-# release build rejects — and clippy on a newer stable actively DEMANDS them
-# (collapsible_if), which the image then cannot compile. Satisfying one broke the other.
-channel = "1.86"
+# They used to disagree: CI floated on `stable` while the image built on 1.86. A laptop
+# and CI would then accept language features (let-chains, stabilized in 1.88) that the
+# release build rejects, while clippy on the newer stable actively DEMANDS them
+# (collapsible_if) — so satisfying one broke the other. Pinning all three down to 1.86
+# was not an option either: cargo-audit now requires 1.88+.
+channel = "1.97"
 components = ["clippy", "rustfmt"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,28 +2,70 @@
 set -eu
 
 LINKS_REPO="git@github.com:jrjones/redirective-links.git"
+DEPLOY_KEY="/run/secrets/links_deploy_key"
 
-# Install deploy key if provided and configure SSH for git
-if [ -f /run/secrets/links_deploy_key ]; then
+# LINKS_REQUIRED gates the fail-loud behavior. Prod MUST set LINKS_REQUIRED=1
+# (see the container-cluster compose): the real links repo must be cloned into
+# /app, and if the deploy key is missing OR the git fetch/checkout fails we
+# exit non-zero and crash-loop instead of silently serving the bundled STUB
+# links.yaml (foo/bar/test). That stub-serving failure took down all ~167 real
+# jrj.io short-links once (ops#138) precisely because it was silent.
+#
+# Dev keeps the friendly default: LINKS_REQUIRED unset/0 + no deploy key =>
+# serve the bundled stub, no network, no crash.
+LINKS_REQUIRED="${LINKS_REQUIRED:-0}"
+
+fail() {
+  echo "FATAL(entrypoint): $1" >&2
+  echo "FATAL(entrypoint): LINKS_REQUIRED=1 — refusing to start on stub links.yaml. Fix the deploy key / links sync and redeploy." >&2
+  exit 1
+}
+
+if [ -f "$DEPLOY_KEY" ]; then
+  # Install deploy key and configure SSH for git
   mkdir -p /root/.ssh
-  cp /run/secrets/links_deploy_key /root/.ssh/id_ed25519
+  cp "$DEPLOY_KEY" /root/.ssh/id_ed25519
   chmod 600 /root/.ssh/id_ed25519
   # Add GitHub to known hosts to avoid interactive prompt
   ssh-keyscan -t ed25519 github.com >> /root/.ssh/known_hosts 2>/dev/null || true
   export GIT_SSH_COMMAND="ssh -i /root/.ssh/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
 
-  # Clone the links repo into /app if not already a git repo
-  # This makes /app the redirective-links repo so git pull works
+  # Clone the links repo into /app if not already a git repo.
+  # This makes /app the redirective-links repo so `git pull` (webhook reload) works.
   if [ ! -d /app/.git ]; then
     echo "Initializing git repo for links..."
     cd /app
-    git init
+    git init -q
     git remote add origin "$LINKS_REPO"
-    git fetch origin main
-    # Remove bundled links.yaml to allow checkout, then checkout main tracking origin
-    rm -f links.yaml
-    git checkout -b main origin/main
-    echo "Links repository initialized."
+    if git fetch origin main; then
+      # The bundled stub links.yaml is untracked and would block the checkout;
+      # stash a copy so we can restore it if checkout unexpectedly fails in dev.
+      cp links.yaml /tmp/links.stub.yaml 2>/dev/null || true
+      rm -f links.yaml
+      if git checkout -b main origin/main; then
+        echo "Links repository initialized from $LINKS_REPO."
+      elif [ "$LINKS_REQUIRED" = "1" ]; then
+        fail "'git checkout origin/main' failed"
+      else
+        echo "WARN: checkout failed; restoring bundled stub links.yaml (LINKS_REQUIRED!=1)." >&2
+        cp /tmp/links.stub.yaml links.yaml 2>/dev/null || true
+      fi
+    elif [ "$LINKS_REQUIRED" = "1" ]; then
+      fail "'git fetch origin main' failed"
+    else
+      echo "WARN: git fetch failed; keeping bundled stub links.yaml (LINKS_REQUIRED!=1)." >&2
+    fi
+  fi
+elif [ "$LINKS_REQUIRED" = "1" ]; then
+  fail "deploy key $DEPLOY_KEY is missing"
+fi
+
+# Belt-and-suspenders: in prod the links repo must actually be present. If we
+# somehow reach here under LINKS_REQUIRED=1 without /app/.git, we would serve
+# the stub — refuse.
+if [ "$LINKS_REQUIRED" = "1" ]; then
+  if [ ! -d /app/.git ]; then
+    fail "/app/.git absent after init — links repo not present, would serve stub"
   fi
 fi
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,10 +140,10 @@ impl Config {
                     service.peer_url = Some(peer);
                 }
             }
-            if let Some(poll_raw) = raw.poll
-                && let Some(secs) = poll_raw.interval_secs
-            {
-                service.poll_interval_secs = Some(secs);
+            if let Some(poll_raw) = raw.poll {
+                if let Some(secs) = poll_raw.interval_secs {
+                    service.poll_interval_secs = Some(secs);
+                }
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,10 +140,10 @@ impl Config {
                     service.peer_url = Some(peer);
                 }
             }
-            if let Some(poll_raw) = raw.poll {
-                if let Some(secs) = poll_raw.interval_secs {
-                    service.poll_interval_secs = Some(secs);
-                }
+            if let Some(poll_raw) = raw.poll
+                && let Some(secs) = poll_raw.interval_secs
+            {
+                service.poll_interval_secs = Some(secs);
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,9 @@
 use crate::errors::Error;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::env;
 use std::fs;
+use std::str::FromStr;
 
 /// Links YAML structure with support for comments.
 #[derive(Deserialize, Debug)]
@@ -35,6 +37,10 @@ pub struct ServiceConfig {
     /// standby node's `/git-webhook` endpoint). Absent = relay disabled.
     #[serde(default)]
     pub peer_url: Option<String>,
+    /// Interval, in seconds, between background `git pull` + reload polls.
+    /// `None` (or `0`) disables polling.
+    #[serde(default = "default_poll_interval_secs")]
+    pub poll_interval_secs: Option<u64>,
 }
 
 fn default_address() -> String {
@@ -46,11 +52,15 @@ fn default_webhook_path() -> String {
 }
 
 fn default_rate_limit_minute() -> u32 {
-    1
+    30
 }
 
 fn default_rate_limit_day() -> u32 {
     100
+}
+
+fn default_poll_interval_secs() -> Option<u64> {
+    Some(60)
 }
 
 /// Overall application configuration.
@@ -70,9 +80,15 @@ struct RawWebhookConfig {
 }
 
 #[derive(Deserialize)]
+struct RawPollConfig {
+    interval_secs: Option<u64>,
+}
+
+#[derive(Deserialize)]
 struct RawServiceConfig {
     address: Option<String>,
     webhook: Option<RawWebhookConfig>,
+    poll: Option<RawPollConfig>,
 }
 
 impl Config {
@@ -101,6 +117,7 @@ impl Config {
             rate_limit_per_minute: default_rate_limit_minute(),
             rate_limit_per_day: default_rate_limit_day(),
             peer_url: None,
+            poll_interval_secs: default_poll_interval_secs(),
         };
 
         // Read service settings from redirective.toml, if available
@@ -123,8 +140,184 @@ impl Config {
                     service.peer_url = Some(peer);
                 }
             }
+            if let Some(poll_raw) = raw.poll
+                && let Some(secs) = poll_raw.interval_secs
+            {
+                service.poll_interval_secs = Some(secs);
+            }
         }
 
+        apply_env_overrides(&mut service);
+
         Ok(Config { links, service })
+    }
+}
+
+/// Parse an env var of type `T`, logging and ignoring it if present but
+/// malformed rather than panicking.
+fn env_override<T: FromStr>(key: &str) -> Option<T> {
+    let raw = env::var(key).ok()?;
+    match raw.parse::<T>() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::warn!(key, value = %raw, "ignoring malformed env override");
+            None
+        }
+    }
+}
+
+/// Apply `REDIRECTIVE_*` env var overrides on top of TOML/defaults. Env wins
+/// over TOML, which wins over the built-in default.
+fn apply_env_overrides(service: &mut ServiceConfig) {
+    if let Ok(raw) = env::var("REDIRECTIVE_POLL_INTERVAL_SECS") {
+        match raw.parse::<u64>() {
+            Ok(0) => service.poll_interval_secs = None,
+            Ok(secs) => service.poll_interval_secs = Some(secs),
+            Err(_) => tracing::warn!(
+                value = %raw,
+                "ignoring malformed REDIRECTIVE_POLL_INTERVAL_SECS"
+            ),
+        }
+    }
+    if let Some(min) = env_override::<u32>("REDIRECTIVE_RATE_LIMIT_PER_MINUTE") {
+        service.rate_limit_per_minute = min;
+    }
+    if let Some(day) = env_override::<u32>("REDIRECTIVE_RATE_LIMIT_PER_DAY") {
+        service.rate_limit_per_day = day;
+    }
+    if let Ok(peer) = env::var("REDIRECTIVE_PEER_URL") {
+        let trimmed = peer.trim();
+        service.peer_url = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Env vars are process-global; serialize the tests that touch them so
+    /// they don't clobber each other when run concurrently.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            unsafe { env::set_var(key, value) };
+            EnvGuard { key }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe { env::remove_var(self.key) };
+        }
+    }
+
+    fn baseline_service() -> ServiceConfig {
+        ServiceConfig {
+            address: default_address(),
+            webhook_path: default_webhook_path(),
+            rate_limit_per_minute: default_rate_limit_minute(),
+            rate_limit_per_day: default_rate_limit_day(),
+            peer_url: None,
+            poll_interval_secs: default_poll_interval_secs(),
+        }
+    }
+
+    #[test]
+    fn test_default_rate_limit_per_minute_is_thirty() {
+        assert_eq!(default_rate_limit_minute(), 30);
+    }
+
+    #[test]
+    fn test_env_override_beats_toml_and_default() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_RATE_LIMIT_PER_MINUTE", "5");
+        let mut service = baseline_service();
+        // Simulate a value already applied from redirective.toml.
+        service.rate_limit_per_minute = 99;
+        apply_env_overrides(&mut service);
+        assert_eq!(service.rate_limit_per_minute, 5);
+    }
+
+    #[test]
+    fn test_no_env_keeps_existing_value() {
+        let _lock = env_lock().lock().unwrap();
+        unsafe { env::remove_var("REDIRECTIVE_RATE_LIMIT_PER_MINUTE") };
+        let mut service = baseline_service();
+        service.rate_limit_per_minute = 7;
+        apply_env_overrides(&mut service);
+        assert_eq!(service.rate_limit_per_minute, 7);
+    }
+
+    #[test]
+    fn test_malformed_env_falls_back_to_current_value() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_RATE_LIMIT_PER_MINUTE", "not-a-number");
+        let mut service = baseline_service();
+        service.rate_limit_per_minute = 42;
+        apply_env_overrides(&mut service);
+        assert_eq!(service.rate_limit_per_minute, 42);
+    }
+
+    #[test]
+    fn test_poll_interval_env_zero_disables() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_POLL_INTERVAL_SECS", "0");
+        let mut service = baseline_service();
+        apply_env_overrides(&mut service);
+        assert_eq!(service.poll_interval_secs, None);
+    }
+
+    #[test]
+    fn test_poll_interval_env_sets_value() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_POLL_INTERVAL_SECS", "45");
+        let mut service = baseline_service();
+        apply_env_overrides(&mut service);
+        assert_eq!(service.poll_interval_secs, Some(45));
+    }
+
+    #[test]
+    fn test_poll_interval_malformed_env_falls_back() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_POLL_INTERVAL_SECS", "soon");
+        let mut service = baseline_service();
+        service.poll_interval_secs = Some(120);
+        apply_env_overrides(&mut service);
+        assert_eq!(service.poll_interval_secs, Some(120));
+    }
+
+    #[test]
+    fn test_peer_url_env_empty_disables() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_PEER_URL", "   ");
+        let mut service = baseline_service();
+        service.peer_url = Some("https://old/git-webhook".to_string());
+        apply_env_overrides(&mut service);
+        assert_eq!(service.peer_url, None);
+    }
+
+    #[test]
+    fn test_peer_url_env_sets_value() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::set("REDIRECTIVE_PEER_URL", "https://peer/git-webhook");
+        let mut service = baseline_service();
+        apply_env_overrides(&mut service);
+        assert_eq!(
+            service.peer_url,
+            Some("https://peer/git-webhook".to_string())
+        );
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -445,10 +445,10 @@ async fn reload_and_relay(
     relay_target: Option<String>,
     git_binary: &str,
 ) {
-    if reload_links(&cache, &metrics, git_binary).await.is_some() {
-        if let Some(peer_url) = relay_target {
-            relay_to_peer(&peer_url, &metrics).await;
-        }
+    if reload_links(&cache, &metrics, git_binary).await.is_some()
+        && let Some(peer_url) = relay_target
+    {
+        relay_to_peer(&peer_url, &metrics).await;
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -445,10 +445,10 @@ async fn reload_and_relay(
     relay_target: Option<String>,
     git_binary: &str,
 ) {
-    if reload_links(&cache, &metrics, git_binary).await.is_some()
-        && let Some(peer_url) = relay_target
-    {
-        relay_to_peer(&peer_url, &metrics).await;
+    if reload_links(&cache, &metrics, git_binary).await.is_some() {
+        if let Some(peer_url) = relay_target {
+            relay_to_peer(&peer_url, &metrics).await;
+        }
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -53,6 +53,11 @@ struct RateLimiter {
     per_day: u32,
 }
 
+/// A client is considered stale, and evicted from the rate limiter map, once
+/// its day window has been idle this long (i.e. it hasn't made a request in
+/// over a day).
+const RATE_LIMIT_DAY_WINDOW: Duration = Duration::from_secs(60 * 60 * 24);
+
 impl RateLimiter {
     fn new(per_minute: u32, per_day: u32) -> Self {
         RateLimiter {
@@ -66,6 +71,12 @@ impl RateLimiter {
     async fn allow(&self, ip: IpAddr) -> bool {
         let now = Instant::now();
         let mut clients = self.clients.lock().await;
+        // Evict stale entries for other clients before growing the map.
+        // `ip` itself is kept regardless so the window-reset logic below can
+        // run on it normally.
+        clients.retain(|&other, info| {
+            other == ip || now.duration_since(info.day_window_start) < RATE_LIMIT_DAY_WINDOW
+        });
         let info = clients.entry(ip).or_insert(RateInfo {
             minute_count: 0,
             minute_window_start: now,
@@ -76,7 +87,7 @@ impl RateLimiter {
             info.minute_window_start = now;
             info.minute_count = 0;
         }
-        if now.duration_since(info.day_window_start) >= Duration::from_secs(60 * 60 * 24) {
+        if now.duration_since(info.day_window_start) >= RATE_LIMIT_DAY_WINDOW {
             info.day_window_start = now;
             info.day_count = 0;
         }
@@ -114,18 +125,21 @@ struct AppState {
     webhook_config: WebhookConfig,
 }
 
-/// Build the Axum application with routes and shared state.
+/// Build the Axum application with routes and shared state. `reload_mutex`
+/// is shared with the background poll task (see `spawn_poll_task`) so the
+/// two reload triggers never race each other's `git pull`.
 fn create_app(
     cache: RouterCache,
     metrics: Metrics,
     version: String,
     service: ServiceConfig,
+    reload_mutex: Arc<TokioMutex<()>>,
 ) -> Router<()> {
     let state = AppState {
         cache,
         metrics,
         version,
-        reload_mutex: Arc::new(TokioMutex::new(())),
+        reload_mutex,
         rate_limiter: Arc::new(RateLimiter::new(
             service.rate_limit_per_minute,
             service.rate_limit_per_day,
@@ -253,6 +267,67 @@ async fn spa_handler(Extension(state): Extension<AppState>, uri: Uri) -> Respons
         .into_response()
 }
 
+/// Returns true if `peer` is loopback or an RFC1918/unique-local private
+/// address, i.e. it can only be our own nginx sitting in front of us.
+///
+/// There's no explicit trusted-proxy list in this codebase; nginx always
+/// reaches us over the docker bridge or loopback, so "peer is private" is an
+/// adequate proxy for "peer is our nginx" without adding a config knob.
+fn is_trusted_proxy(peer: IpAddr) -> bool {
+    match peer {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_private(),
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() {
+                true
+            } else if let Some(mapped) = v6.to_ipv4_mapped() {
+                mapped.is_loopback() || mapped.is_private()
+            } else {
+                // fc00::/7 (unique local).
+                (v6.segments()[0] & 0xfe00) == 0xfc00
+            }
+        }
+    }
+}
+
+/// Extract a single IP address from a header value, treating a
+/// missing/empty/unparseable value as absent.
+fn header_ip(headers: &HeaderMap, name: &str) -> Option<IpAddr> {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<IpAddr>().ok())
+}
+
+/// Resolve the real client IP for rate-limiting purposes.
+///
+/// Only trusts `X-Real-IP`/`X-Forwarded-For` when `peer` (the TCP peer) is
+/// our own nginx (see `is_trusted_proxy`); a public peer means the request
+/// didn't come through our proxy, so its headers could be spoofed and are
+/// ignored in favor of the peer address itself. nginx sets
+/// `X-Real-IP $http_cf_connecting_ip`, which is empty for non-CloudFlare
+/// (tailnet) requests, so an empty header is treated the same as absent.
+fn resolve_client_ip(peer: IpAddr, headers: &HeaderMap) -> IpAddr {
+    if !is_trusted_proxy(peer) {
+        return peer;
+    }
+    if let Some(ip) = header_ip(headers, "x-real-ip") {
+        return ip;
+    }
+    let xff_first = headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<IpAddr>().ok());
+    if let Some(ip) = xff_first {
+        return ip;
+    }
+    peer
+}
+
 /// Decide whether this webhook should be relayed to a peer.
 ///
 /// Returns the peer URL to relay to when `peer_url` is configured and the
@@ -307,6 +382,60 @@ async fn relay_to_peer(peer_url: &str, metrics: &Metrics) {
     }
 }
 
+/// Run `git rev-parse HEAD` in `repo_dir`, returning the trimmed commit hash
+/// on success. Used only to detect whether a pull actually moved HEAD.
+fn git_head(git_binary: &str, repo_dir: &std::path::Path) -> Option<String> {
+    Command::new(git_binary)
+        .current_dir(repo_dir)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+}
+
+/// Run `git pull --ff-only` and, on success, reload the link table from
+/// `links.yaml` into `cache`.
+///
+/// Returns `Some(changed)` on a successful reload, where `changed` reports
+/// whether the pull actually moved HEAD (useful for quiet-steady-state
+/// logging), or `None` if the pull or the reload failed. Metrics are
+/// incremented here so every caller gets consistent accounting.
+async fn reload_links(cache: &RouterCache, metrics: &Metrics, git_binary: &str) -> Option<bool> {
+    let repo_dir = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+
+    let before = git_head(git_binary, &repo_dir);
+
+    let pulled = Command::new(git_binary)
+        .current_dir(&repo_dir)
+        .args(["pull", "--ff-only"])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if !pulled {
+        metrics.reload_fail.inc();
+        return None;
+    }
+
+    let cfg = match Config::load("links.yaml") {
+        Ok(cfg) => cfg,
+        Err(_) => {
+            metrics.reload_fail.inc();
+            return None;
+        }
+    };
+
+    let mut codes: Vec<String> = cfg.links.keys().cloned().collect();
+    codes.sort();
+    let _ = std::fs::write("static_html/shortcodes.txt", codes.join("\n"));
+    cache.swap(cfg.links);
+    metrics.reload_success.inc();
+
+    let after = git_head(git_binary, &repo_dir);
+    Some(before.is_some() && after != before)
+}
+
 /// Run a git pull and reload the link table, then (only on a successful
 /// reload) relay the webhook to `relay_target`, if any. Relay failures do
 /// not affect the reload outcome.
@@ -316,35 +445,55 @@ async fn reload_and_relay(
     relay_target: Option<String>,
     git_binary: &str,
 ) {
-    let repo_dir = env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-    if let Ok(status) = Command::new(git_binary)
-        .current_dir(&repo_dir)
-        .args(["pull", "--ff-only"])
-        .status()
+    if reload_links(&cache, &metrics, git_binary).await.is_some()
+        && let Some(peer_url) = relay_target
     {
-        if status.success() {
-            if let Ok(cfg) = Config::load("links.yaml") {
-                if env::current_dir().is_ok() {
-                    let mut codes: Vec<String> = cfg.links.keys().cloned().collect();
-                    codes.sort();
-                    let content = codes.join("\n");
-                    let _ = std::fs::write("static_html/shortcodes.txt", &content);
-                }
-                cache.swap(cfg.links);
-                metrics.reload_success.inc();
-                // Only a successful reload propagates to the peer.
-                if let Some(peer_url) = relay_target {
-                    relay_to_peer(&peer_url, &metrics).await;
-                }
-            } else {
-                metrics.reload_fail.inc();
-            }
-        } else {
-            metrics.reload_fail.inc();
-        }
-    } else {
-        metrics.reload_fail.inc();
+        relay_to_peer(&peer_url, &metrics).await;
     }
+}
+
+/// Convert a configured poll interval into a `Duration`, treating `None` or
+/// `0` as "polling disabled". Kept side-effect free so it can be unit
+/// tested without touching tokio's clock.
+fn poll_interval(poll_interval_secs: Option<u64>) -> Option<Duration> {
+    match poll_interval_secs {
+        None | Some(0) => None,
+        Some(secs) => Some(Duration::from_secs(secs)),
+    }
+}
+
+/// Spawn the background git-poll reload task, if `poll_interval_secs`
+/// enables it. Shares `reload_mutex` with the webhook handler so a poll and
+/// a webhook-triggered reload never run `git pull` concurrently.
+fn spawn_poll_task(
+    cache: RouterCache,
+    metrics: Metrics,
+    reload_mutex: Arc<TokioMutex<()>>,
+    poll_interval_secs: Option<u64>,
+) {
+    let Some(interval) = poll_interval(poll_interval_secs) else {
+        tracing::info!("git-poll reload disabled (poll_interval_secs unset or 0)");
+        return;
+    };
+    tracing::info!(
+        interval_secs = interval.as_secs(),
+        "git-poll reload enabled"
+    );
+    task::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // The first tick fires immediately; links are already fresh from
+        // startup, so skip it and only reload on subsequent ticks.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let _guard = reload_mutex.lock().await;
+            match reload_links(&cache, &metrics, GIT_BINARY).await {
+                Some(true) => tracing::info!("git-poll reload: links changed"),
+                Some(false) => {}
+                None => tracing::warn!("git-poll reload: pull or reload failed"),
+            }
+        }
+    });
 }
 
 /// Webhook endpoint to trigger a git pull and reload.
@@ -353,7 +502,7 @@ async fn webhook_handler(
     Extension(state): Extension<AppState>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
-    let ip = addr.ip();
+    let ip = resolve_client_ip(addr.ip(), &headers);
     if !state.rate_limiter.allow(ip).await {
         return StatusCode::TOO_MANY_REQUESTS.into_response();
     }
@@ -375,7 +524,14 @@ pub async fn run_http_server(
     service: ServiceConfig,
 ) -> Result<(), Error> {
     let version = env!("CARGO_PKG_VERSION").to_string();
-    let app = create_app(cache, metrics, version, service.clone());
+    let reload_mutex = Arc::new(TokioMutex::new(()));
+    spawn_poll_task(
+        cache.clone(),
+        metrics.clone(),
+        reload_mutex.clone(),
+        service.poll_interval_secs,
+    );
+    let app = create_app(cache, metrics, version, service.clone(), reload_mutex);
     let addr: SocketAddr = service.address.parse()?;
     axum::Server::bind(&addr)
         .serve(app.into_make_service_with_connect_info::<SocketAddr>())
@@ -402,14 +558,25 @@ mod tests {
             rate_limit_per_minute: 1,
             rate_limit_per_day: 100,
             peer_url: None,
+            poll_interval_secs: None,
         }
+    }
+
+    fn new_reload_mutex() -> Arc<TokioMutex<()>> {
+        Arc::new(TokioMutex::new(()))
     }
 
     #[tokio::test]
     async fn test_healthz() {
         let cache = RouterCache::new(HashMap::new());
         let metrics = init_metrics();
-        let app = create_app(cache, metrics, "1.2.3".to_string(), default_service());
+        let app = create_app(
+            cache,
+            metrics,
+            "1.2.3".to_string(),
+            default_service(),
+            new_reload_mutex(),
+        );
         let response = app
             .clone()
             .oneshot(
@@ -429,7 +596,13 @@ mod tests {
     async fn test_version() {
         let cache = RouterCache::new(HashMap::new());
         let metrics = init_metrics();
-        let app = create_app(cache, metrics, "vX.Y".to_string(), default_service());
+        let app = create_app(
+            cache,
+            metrics,
+            "vX.Y".to_string(),
+            default_service(),
+            new_reload_mutex(),
+        );
         let response = app
             .clone()
             .oneshot(
@@ -451,7 +624,13 @@ mod tests {
         map.insert("foo".to_string(), "http://example.com".to_string());
         let cache = RouterCache::new(map);
         let metrics = init_metrics();
-        let app = create_app(cache, metrics, "1.0".to_string(), default_service());
+        let app = create_app(
+            cache,
+            metrics,
+            "1.0".to_string(),
+            default_service(),
+            new_reload_mutex(),
+        );
         let response = app
             .clone()
             .oneshot(
@@ -473,7 +652,13 @@ mod tests {
         map.insert("foo".to_string(), "http://example.com".to_string());
         let cache = RouterCache::new(map);
         let metrics = init_metrics();
-        let app = create_app(cache, metrics, "1.0".to_string(), default_service());
+        let app = create_app(
+            cache,
+            metrics,
+            "1.0".to_string(),
+            default_service(),
+            new_reload_mutex(),
+        );
         let response = app
             .clone()
             .oneshot(
@@ -593,5 +778,144 @@ mod tests {
         assert_eq!(metrics.reload_success.get(), 1);
         assert_eq!(metrics.relay_success.get(), 0);
         assert_eq!(metrics.relay_fail.get(), 1);
+    }
+
+    fn loopback_peer() -> IpAddr {
+        IpAddr::from([127, 0, 0, 1])
+    }
+
+    fn public_peer() -> IpAddr {
+        IpAddr::from([203, 0, 113, 5])
+    }
+
+    #[test]
+    fn test_is_trusted_proxy_loopback_and_private() {
+        assert!(is_trusted_proxy(loopback_peer()));
+        assert!(is_trusted_proxy(IpAddr::from([10, 0, 0, 5])));
+        assert!(is_trusted_proxy(IpAddr::from([172, 17, 0, 2])));
+        assert!(is_trusted_proxy(IpAddr::from([192, 168, 1, 1])));
+        assert!(is_trusted_proxy(std::net::Ipv6Addr::LOCALHOST.into()));
+    }
+
+    #[test]
+    fn test_is_trusted_proxy_public_is_not_trusted() {
+        assert!(!is_trusted_proxy(public_peer()));
+    }
+
+    #[test]
+    fn test_resolve_client_ip_honors_x_real_ip_from_loopback() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "203.0.113.9".parse().unwrap());
+        assert_eq!(
+            resolve_client_ip(loopback_peer(), &headers),
+            IpAddr::from([203, 0, 113, 9])
+        );
+    }
+
+    #[test]
+    fn test_resolve_client_ip_ignores_spoofed_header_from_public_peer() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "203.0.113.9".parse().unwrap());
+        // A public peer isn't our nginx, so the header must be ignored and
+        // the peer address used instead - otherwise any caller could set
+        // X-Real-IP and bypass the rate limiter entirely.
+        assert_eq!(resolve_client_ip(public_peer(), &headers), public_peer());
+    }
+
+    #[test]
+    fn test_resolve_client_ip_uses_leftmost_xff_entry() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "203.0.113.9, 10.0.0.1, 10.0.0.2".parse().unwrap(),
+        );
+        assert_eq!(
+            resolve_client_ip(loopback_peer(), &headers),
+            IpAddr::from([203, 0, 113, 9])
+        );
+    }
+
+    #[test]
+    fn test_resolve_client_ip_empty_header_treated_as_absent() {
+        let mut headers = HeaderMap::new();
+        // nginx sets X-Real-IP to $http_cf_connecting_ip, which is empty for
+        // non-CloudFlare (tailnet) traffic.
+        headers.insert("x-real-ip", "".parse().unwrap());
+        headers.insert("x-forwarded-for", "10.0.0.7".parse().unwrap());
+        assert_eq!(
+            resolve_client_ip(loopback_peer(), &headers),
+            IpAddr::from([10, 0, 0, 7])
+        );
+    }
+
+    #[test]
+    fn test_resolve_client_ip_falls_back_to_peer_when_no_headers() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            resolve_client_ip(loopback_peer(), &headers),
+            loopback_peer()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_allows_n_then_blocks_nplus1() {
+        let limiter = RateLimiter::new(2, 100);
+        let ip = IpAddr::from([192, 168, 1, 50]);
+        assert!(limiter.allow(ip).await);
+        assert!(limiter.allow(ip).await);
+        assert!(!limiter.allow(ip).await);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_tracks_ips_independently() {
+        let limiter = RateLimiter::new(1, 100);
+        let a = IpAddr::from([192, 168, 1, 1]);
+        let b = IpAddr::from([192, 168, 1, 2]);
+        assert!(limiter.allow(a).await);
+        assert!(!limiter.allow(a).await);
+        // A different IP has its own budget.
+        assert!(limiter.allow(b).await);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_evicts_stale_entries() {
+        let limiter = RateLimiter::new(10, 100);
+        let stale_ip = IpAddr::from([192, 168, 1, 99]);
+        let now = Instant::now();
+        let stale_start = now
+            .checked_sub(RATE_LIMIT_DAY_WINDOW + Duration::from_secs(1))
+            .expect("test process has been up over a day");
+        {
+            let mut clients = limiter.clients.lock().await;
+            clients.insert(
+                stale_ip,
+                RateInfo {
+                    minute_count: 5,
+                    minute_window_start: stale_start,
+                    day_count: 5,
+                    day_window_start: stale_start,
+                },
+            );
+        }
+        let fresh_ip = IpAddr::from([192, 168, 1, 100]);
+        assert!(limiter.allow(fresh_ip).await);
+        let clients = limiter.clients.lock().await;
+        assert!(!clients.contains_key(&stale_ip));
+        assert!(clients.contains_key(&fresh_ip));
+    }
+
+    #[test]
+    fn test_poll_interval_none_when_unset() {
+        assert_eq!(poll_interval(None), None);
+    }
+
+    #[test]
+    fn test_poll_interval_none_when_zero() {
+        assert_eq!(poll_interval(Some(0)), None);
+    }
+
+    #[test]
+    fn test_poll_interval_some_when_positive() {
+        assert_eq!(poll_interval(Some(60)), Some(Duration::from_secs(60)));
     }
 }


### PR DESCRIPTION
Fixes the 429 reported in rimrock-systems/operations#164 — and two worse bugs behind it.

**Supersedes #15** — this branch is based on it, so the `LINKS_REQUIRED` entrypoint hardening is included here and a single image rebuild carries both. (ops#144 is blocked on exactly that rebuild.)

## 1. The rate limiter was global, not per-IP

`webhook_handler` keyed on the `ConnectInfo` TCP peer. Behind nginx that is *always* the same address, so `rate_limit_per_minute = 1` was really **1 request/minute globally**.

The actual trigger: a **native repo webhook on `redirective-links` (created 2026-07-07)** fired on push and consumed the single token, then the Action's curl landed ~15s later *in the same minute* → 429. The hook has been deleted (it also bypassed the Action's YAML-validation gate), but the limiter was still wrong.

Now resolves the real client — `X-Real-IP`, else leftmost `X-Forwarded-For` — and **only trusts those headers when the peer is loopback/RFC1918**, i.e. our own nginx. From a public peer the headers are ignored outright, so the limiter cannot be spoofed past. Default raised 1 → 30.

## 2. A webhook only ever reloaded ONE node

`peer_url` was unset in prod. `jrj.io` is **dual-A** across corellia and tatooine, so a webhook lands on one node — the other served stale links until the next deploy. Silently: Kuma canary #25 checks an *existing* link, so it stays green, and an unknown code returns `200` (SPA fallback) rather than erroring.

Rather than make the relay reachable (the fleet is off-tailnet and nginx `444`s direct-IP hits, so it'd need new `server_name` + firewall work), **each node now polls git on an interval and converges independently**. The webhook stays as an accelerator. This deletes the whole problem class — rate limits, relay reachability, and dual-A routing all stop mattering.

## 3. Config was unreachable without a rebuild

TOML-only, baked into the image. Added env overrides (env > TOML > default): `REDIRECTIVE_POLL_INTERVAL_SECS`, `REDIRECTIVE_RATE_LIMIT_PER_MINUTE`, `REDIRECTIVE_RATE_LIMIT_PER_DAY`, `REDIRECTIVE_PEER_URL`. Malformed values warn and fall back rather than panicking.

## Notes

- The poll and the webhook share **one** reload path (`reload_links`) behind a mutex — one `git pull` implementation, and the two triggers can't race.
- The limiter map, now keyed on many real IPs instead of one, evicts idle day-windows instead of growing forever.
- The poll is quiet in steady state: it only logs when a reload actually changes `HEAD`.

## Verification

Locally, against a real git remote:
- **5 rapid webhook POSTs → all `202`.** (Previously: `202` then 4× `429`.)
- **A link pushed to origin with NO webhook call is serving `302` within one poll tick.**
- 38 tests pass (21 new: trusted-proxy classification, spoofed `X-Real-IP` from a public peer rejected, XFF leftmost, empty-header-as-absent, limiter N-then-429, stale eviction, env-override precedence incl. malformed fallback). `cargo clippy -D warnings` clean.

Pairs with the operations-side PR that sets `REDIRECTIVE_POLL_INTERVAL_SECS` and `LINKS_REQUIRED=1` in the compose file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: infrabot <infrabot@rimrock.systems>